### PR TITLE
Fix return code for --help and --version

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -101,6 +101,11 @@ int debug = 0;
 static int gargc = 0;
 static char** gargv = NULL;
 
+int successexit(const char* text) {
+	printf("%s\n", text);
+	return 0;
+}
+
 int errorexit(const char* text) {
 	fprintf(stderr, "%s\n", text);
 	return -1;
@@ -416,14 +421,17 @@ static char* getconfcmdargs(const char* name) {
 	return NULL;
 }
 
+/* A positive return value indicates the caller to proceed. A zero return value means the
+   program should terminate sucessfully after option processing, while a negative return
+   value indicates an error during argument processing. */
 int qtprocessargs(int argc, char** argv) {
 	int i;
 	for (i = 1; i < argc; i++) {
 		char* a = argv[i];
 		if (!strcmp(a, "-h") || !strcmp(a, "--help")) {
-			return errorexit("Please read the documentation at http://wiki.ucis.nl/QuickTun");
+			return successexit("Please read the documentation at http://wiki.ucis.nl/QuickTun");
 		} else if (!strcmp(a, "-v") || !strcmp(a, "--version")) {
-			return errorexit("UCIS QuickTun "QT_VERSION);
+			return successexit("UCIS QuickTun "QT_VERSION);
 		} else if (!strcmp(a, "-c")) {
 			gargc = argc;
 			gargv = argv;
@@ -433,7 +441,7 @@ int qtprocessargs(int argc, char** argv) {
 			return errorexit("Unexpected command line argument");
 		}
 	}
-	return 0;
+	return 1;
 }
 #endif
 

--- a/src/run.combined.c
+++ b/src/run.combined.c
@@ -44,13 +44,14 @@ char* getenvdeb(const char* name) {
 #endif
 
 int main(int argc, char** argv) {
-	print_header();
 #ifdef DEBIAN_BINARY
 	getconf = getenvdeb;
 #else
 	getconf = getenv;
 #endif
-	if (qtprocessargs(argc, argv) < 0) return -1;
+	int rc = qtprocessargs(argc, argv);
+	if (rc <= 0) return rc;
+	print_header();
 	char* envval;
 	if ((envval = getconf("PROTOCOL"))) {
 		if (strcmp(envval, "raw") == 0) {


### PR DESCRIPTION
When the `--help' or `--version' command-line options were given,
quicktun would exit with exit status 1, although the requested action
was fulfilled without encountering an error. With this change, these
options now will result in a zero exit status.

In addition, with both of these option, the header printed was partially
overlapping with the message printed by the option, so the header
is now printer after option processing.