### PR TITLE
Fix compiler warnings with libsodium

### DIFF
--- a/src/proto.nacl0.c
+++ b/src/proto.nacl0.c
@@ -80,8 +80,7 @@ static int init(struct qtsession* sess) {
 	} else {
 		return errorexit("Missing PRIVATE_KEY");
 	}
-	crypto_box_curve25519xsalsa20poly1305_beforenm(d->cbefore, cpublickey, csecretkey);
-	return 0;
+	return crypto_box_curve25519xsalsa20poly1305_beforenm(d->cbefore, cpublickey, csecretkey);
 }
 
 struct qtproto qtproto_nacl0 = {

--- a/src/proto.nacltai.c
+++ b/src/proto.nacltai.c
@@ -138,7 +138,9 @@ static int init(struct qtsession* sess) {
 	} else {
 		return errorexit("Missing PRIVATE_KEY");
 	}
-	crypto_box_curve25519xsalsa20poly1305_beforenm(d->cbefore, cpublickey, csecretkey);
+	if (crypto_box_curve25519xsalsa20poly1305_beforenm(d->cbefore, cpublickey, csecretkey) != 0) {
+		return -1;
+        }
 
 	memset(d->cenonce, 0, crypto_box_curve25519xsalsa20poly1305_NONCEBYTES);
 	memset(d->cdnonce, 0, crypto_box_curve25519xsalsa20poly1305_NONCEBYTES);


### PR DESCRIPTION
When compiling using libsodium and GCC or clang, some compiler
warnings were produced due to ignored return values. Change the
offending call sites to propagate the error condition to the caller.

Also, remove `encodeuint32`: this function was not used (found by
using the -Wall GCC option).
