### PR TITLE
Check if $cc and $ARCH variables exist from command line

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,9 @@
 set -e
 
 tar="tar"
-cc="cc"
+if [ ! $cc ]; then
+	cc="cc"
+fi
 
 if [ "$(uname -s)" = "OpenBSD" -o "$(uname -s)" = "FreeBSD" -o "$(uname -s)" = "NetBSD" ]; then
 	echo "Detected *BSD"

--- a/deb/build.sh
+++ b/deb/build.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -e
 VERSION=`cat ../version`-0
-ARCH=`dpkg --print-architecture`
+if [ ! $ARCH ]; then
+	ARCH=`dpkg --print-architecture`
+fi
 rm -r data 2>/dev/null || true
 cp -r static data
 mkdir -p data/usr data/usr/sbin data/DEBIAN


### PR DESCRIPTION
When using crossbuild to target MIPS, for example, the attached patches allow specifying some architecture-specific parameters on the command line:

`cc="mipsel-linux-gnu-cc" ARCH="mipsel" LDFLAGS="-L./tmp/lib" ./build.sh`